### PR TITLE
Allow NetworkManager to create Bluetooth SDP sockets

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -51,6 +51,7 @@ allow NetworkManager_t self:netlink_kobject_uevent_socket create_socket_perms;
 allow NetworkManager_t self:tcp_socket { accept listen };
 allow NetworkManager_t self:tun_socket { create_socket_perms relabelfrom relabelto };
 allow NetworkManager_t self:packet_socket create_socket_perms;
+allow NetworkManager_t self:socket create_socket_perms;
 
 allow NetworkManager_t wpa_cli_t:unix_dgram_socket sendto;
 


### PR DESCRIPTION
It's going to do the the discovery for DUN service for modems with Bluez 5.
