### PR TITLE
pulse: don't give pulseaudio_client full access to user_home_t

### DIFF
--- a/pulseaudio.te
+++ b/pulseaudio.te
@@ -227,9 +227,6 @@ pulseaudio_home_filetrans_pulseaudio_home(pulseaudio_client, file, ".esd_auth")
 pulseaudio_home_filetrans_pulseaudio_home(pulseaudio_client, file, ".pulse-cookie")
 pulseaudio_signull(pulseaudio_client)
 
-# TODO: ~/.cache
-userdom_manage_user_home_content_files(pulseaudio_client)
-
 userdom_read_user_tmpfs_files(pulseaudio_client)
 # userdom_delete_user_tmpfs_files(pulseaudio_client)
 


### PR DESCRIPTION
This doesn't seem to be necessary at all, and the comment immediately
above it doesn't make things any less mysterious, as pulseaudio clients
don't even need access to ~/.cache. I cannot observe any breakage on my
machine due to this change, and the permission being present was causing
unexpected behavior (eg. Skype could freely read the contents of my home
dir even with the boolean supposedly toggling that permission disabled,
because skype_t was marked as pulseaudio_client and thus had full access
regardless).

The original source seems to be 5851ec54, which doesn't really help
explaining the original purpose of the lines.