### PR TITLE
Transition D-Bus system service out of the init_t domain when PID1 is…

### DIFF
--- a/dbus.if
+++ b/dbus.if
@@ -562,6 +562,10 @@ interface(`dbus_system_domain',`
 
 	userdom_read_all_users_state($1)
 
+	ifdef(`init_systemd',`
+		init_daemon_domain($1, $2)
+	')
+
 	ifdef(`hide_broken_symptoms', `
 		dontaudit $1 system_dbusd_t:netlink_selinux_socket { read write };
 	')


### PR DESCRIPTION
… systemd

D-Bus is not starting the activated system services anymore when PID1 is
systemd, but it delegate the job to systemd.