### PR TITLE
Fix typos in contrib module interfaces

### DIFF
--- a/amanda.if
+++ b/amanda.if
@@ -105,7 +105,7 @@ interface(`amanda_rw_dumpdates_files',`
 
 ########################################
 ## <summary>
-##	Search Amanda library directories.
+##	Manage Amanda library directories.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/bind.if
+++ b/bind.if
@@ -2,7 +2,8 @@
 
 ########################################
 ## <summary>
-##	Execute bind server in the bind domain.
+##	Execute bind init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/cgroup.if
+++ b/cgroup.if
@@ -42,8 +42,8 @@ interface(`cgroup_domtrans_cgconfig',`
 
 ########################################
 ## <summary>
-##	Execute a domain transition to run
-##	CG config parser.
+##	Execute CG config init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/kdump.if
+++ b/kdump.if
@@ -21,7 +21,8 @@ interface(`kdump_domtrans',`
 
 #######################################
 ## <summary>
-##	Execute kdump in the kdump domain.
+##	Execute kdump init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/nis.if
+++ b/nis.if
@@ -318,7 +318,8 @@ interface(`nis_domtrans_ypxfr',`
 
 ########################################
 ## <summary>
-##	Execute nis server in the nis domain.
+##	Execute nis init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -337,7 +338,8 @@ interface(`nis_initrc_domtrans',`
 
 ########################################
 ## <summary>
-##	Execute nis server in the nis domain.
+##	Execute ypbind init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/ntp.if
+++ b/ntp.if
@@ -82,7 +82,8 @@ interface(`ntp_domtrans_ntpdate',`
 
 ########################################
 ## <summary>
-##	Execute ntp server in the ntpd domain.
+##	Execute ntpd init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/ntp.if
+++ b/ntp.if
@@ -63,7 +63,7 @@ interface(`ntp_run',`
 
 ########################################
 ## <summary>
-##	Execute ntp server in the ntpd domain.
+##	Execute ntpdate server in the ntpd domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/shorewall.if
+++ b/shorewall.if
@@ -21,7 +21,8 @@ interface(`shorewall_domtrans',`
 
 ######################################
 ## <summary>
-##	Execute a domain transition to run shorewall.
+##	Execute a domain transition to run shorewall
+##	using executables from /var/lib.
 ## </summary>
 ## <param name="domain">
 ## <summary>

--- a/virt.if
+++ b/virt.if
@@ -189,7 +189,7 @@ interface(`virt_domtrans_bridgehelper',`
 ########################################
 ## <summary>
 ##	Execute a domain transition to
-##	run virt bridgehelper.
+##	run virt leaseshelper.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -434,8 +434,7 @@ interface(`virt_manage_config',`
 
 ########################################
 ## <summary>
-##	Create, read, write, and delete
-##	virt image files.
+##	Read virt content.
 ## </summary>
 ## <param name="domain">
 ##	<summary>


### PR DESCRIPTION
Hello, these two patches belong to the same work which inspired https://github.com/TresysTechnology/refpolicy/pull/21 , but for the contrib modules. Could you please merge them?
Thanks