### PR TITLE
Add read/write perms for redis-sentinel

### DIFF
--- a/redis.fc
+++ b/redis.fc
@@ -7,3 +7,5 @@
 /var/log/redis(/.*)?	gen_context(system_u:object_r:redis_log_t,s0)
 
 /var/run/redis(/.*)?	gen_context(system_u:object_r:redis_var_run_t,s0)
+
+/etc/redis.*\.conf -- gen_context(system_u:object_r:redis_conf_t,s0)

--- a/redis.if
+++ b/redis.if
@@ -20,7 +20,7 @@
 interface(`redis_admin',`
 	gen_require(`
 		type redis_t, redis_initrc_exec_t, redis_var_lib_t;
-		type redis_log_t, redis_var_run_t;
+		type redis_log_t, redis_var_run_t, redis_conf_t;
 	')
 
 	allow $1 redis_t:process { ptrace signal_perms };
@@ -36,4 +36,7 @@ interface(`redis_admin',`
 
 	files_search_pids($1)
 	admin_pattern($1, redis_var_run_t)
+
+	files_search_config($1)
+	admin_pattern($1, redis_conf_t)
 ')

--- a/redis.te
+++ b/redis.te
@@ -21,6 +21,9 @@ files_type(redis_var_lib_t)
 type redis_var_run_t;
 files_pid_file(redis_var_run_t)
 
+type redis_conf_t;
+files_config_file(redis_conf_t)
+
 ########################################
 #
 # Local policy
@@ -30,6 +33,7 @@ allow redis_t self:process { setrlimit signal_perms };
 allow redis_t self:fifo_file rw_fifo_file_perms;
 allow redis_t self:unix_stream_socket create_stream_socket_perms;
 allow redis_t self:tcp_socket create_stream_socket_perms;
+allow redis_t redis_conf_t:file rw_file_perms;
 
 manage_dirs_pattern(redis_t, redis_log_t, redis_log_t)
 manage_files_pattern(redis_t, redis_log_t, redis_log_t)


### PR DESCRIPTION
Fixes
```
type=AVC msg=audit(1454110519.451:77): avc:  denied  { read } for  pid=2863 comm="redis-sentinel" name="redis-sentinel.conf" dev="dm-0" ino=69275142 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file
type=AVC msg=audit(1454110519.451:77): avc:  denied  { open } for  pid=2863 comm="redis-sentinel" path="/etc/redis-sentinel.conf" dev="dm-0" ino=69275142 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file
type=AVC msg=audit(1454110519.451:78): avc:  denied  { getattr } for  pid=2863 comm="redis-sentinel" path="/etc/redis-sentinel.conf" dev="dm-0" ino=69275142 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file
type=AVC msg=audit(1454110519.457:80): avc:  denied  { write } for  pid=2863 comm="redis-sentinel" name="redis-sentinel.conf" dev="dm-0" ino=69275142 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file
```