### PR TITLE
Allow tcp_connect to redis_port_t for redis_t

### DIFF
--- a/redis.te
+++ b/redis.te
@@ -58,6 +58,7 @@ corenet_tcp_bind_generic_node(redis_t)
 
 corenet_sendrecv_redis_server_packets(redis_t)
 corenet_tcp_bind_redis_port(redis_t)
+corenet_tcp_connect_redis_port(redis_t)
 corenet_tcp_sendrecv_redis_port(redis_t)
 
 dev_read_sysfs(redis_t)


### PR DESCRIPTION
This fixes the following:
```
type=AVC msg=audit(1455747105.487:947088): avc:  denied  { name_connect } for  pid=2390 comm="redis-server" dest=26379 scontext=system_u:system_r:redis_t:s0 tcontext=system_u:object_r:redis_port_t:s0 tclass=tcp_socket
```

The `redis-server` process must be allowed to make outbound connections when running in a master-slave configuration.