### PR TITLE
Add Arch Linux path for geoclue module

### DIFF
--- a/geoclue.fc
+++ b/geoclue.fc
@@ -1,5 +1,6 @@
 /etc/geoclue(/.*)? 			gen_context(system_u:object_r:geoclue_etc_t,s0)
 
+/usr/lib/geoclue2/geoclue	--	gen_context(system_u:object_r:geoclue_exec_t,s0)
 /usr/lib/geoclue-2\.0/geoclue	--	gen_context(system_u:object_r:geoclue_exec_t,s0)
 
 /usr/libexec/geoclue		--	gen_context(system_u:object_r:geoclue_exec_t,s0)


### PR DESCRIPTION
This has bitten me when I installed Redshift on my computer, as this program uses geoclue to adjust its configuration depending on the location of the computer.