### PR TITLE
Allow puppet_t transtition to shorewall_t

### DIFF
--- a/puppet.te
+++ b/puppet.te
@@ -200,6 +200,10 @@ optional_policy(`
 	usermanage_domtrans_useradd(puppet_t)
 ')
 
+optional_policy(`
+        shorewall_domtrans(puppet_t)
+')
+
 ########################################
 #
 # Ca local policy


### PR DESCRIPTION
If puppet executes /sbin/shorewall it won't transition to
shorewall_t and create log files with puppet_log_t context
instead of shorewall_log_t. If service is then managed by
init (sysv/systemd) it will fail to start.

If puppet_t is allowed to transtition to shorewall_t the
logfile will get the correct shorewall_log_t type.