### PR TITLE
Syncthing Policy Module

### DIFF
--- a/syncthing.fc
+++ b/syncthing.fc
@@ -1,0 +1,3 @@
+/usr/bin/syncthing                      -- gen_context(system_u:object_r:syncthing_exec_t,s0)
+
+HOME_DIR/\.config/syncthing(/.*)?          gen_context(system_u:object_r:syncthing_config_home_t,s0)

--- a/syncthing.if
+++ b/syncthing.if
@@ -1,0 +1,32 @@
+## <summary>Application that lets you synchronize your files across multiple devices.</summary>
+
+########################################
+## <summary>
+##  Role access for Syncthing
+## </summary>
+## <param name="role">
+##  <summary>
+##  Role allowed access
+##  </summary>
+## </param>
+## <param name="domain">
+##  <summary>
+##  User domain for the role
+##  </summary>
+## </param>
+#
+interface(`syncthing_role', `
+
+    gen_require(`
+        attribute_role syncthing_roles;
+        type syncthing_t, syncthing_exec_t, syncthing_config_home_t;
+    ')
+
+    roleattribute $1 syncthing_roles;
+
+    domtrans_pattern($2, syncthing_exec_t, syncthing_t)
+
+    allow $2 syncthing_config_home_t:file { manage_file_perms relabel_file_perms };
+    allow $2 syncthing_config_home_t:dir { manage_dir_perms relabel_dir_perms };
+    allow $2 syncthing_config_home_t:lnk_file { manage_lnk_file_perms relabel_lnk_file_perms };
+')

--- a/syncthing.te
+++ b/syncthing.te
@@ -1,0 +1,78 @@
+policy_module(syncthing, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role syncthing_roles;
+role syncthing_roles types syncthing_t;
+
+type syncthing_t;
+type syncthing_exec_t;
+init_daemon_domain(syncthing_t, syncthing_exec_t)
+userdom_user_application_domain(syncthing_t, syncthing_exec_t)
+
+type syncthing_config_home_t;
+userdom_user_home_content(syncthing_config_home_t)
+
+########################################
+#
+# Declarations
+#
+
+allow syncthing_t self:process getsched;
+allow syncthing_t self:fifo_file rw_fifo_file_perms;
+allow syncthing_t self:tcp_socket { listen accept };
+
+can_exec(syncthing_t, syncthing_exec_t)
+
+kernel_read_kernel_sysctls(syncthing_t)
+kernel_read_net_sysctls(syncthing_t)
+kernel_read_system_state(syncthing_t)
+
+corenet_tcp_sendrecv_generic_if(syncthing_t)
+corenet_udp_sendrecv_generic_if(syncthing_t)
+
+corenet_tcp_bind_generic_node(syncthing_t)
+corenet_tcp_sendrecv_generic_node(syncthing_t)
+corenet_tcp_sendrecv_all_ports(syncthing_t)
+
+corenet_udp_bind_generic_node(syncthing_t)
+corenet_udp_sendrecv_generic_node(syncthing_t)
+corenet_udp_sendrecv_all_ports(syncthing_t)
+
+corenet_tcp_connect_all_ports(syncthing_t)
+
+corenet_tcp_bind_syncthing_port(syncthing_t)
+corenet_udp_bind_syncthing_discovery_port(syncthing_t)
+corenet_tcp_bind_syncthing_admin_port(syncthing_t)
+
+dev_read_rand(syncthing_t)
+dev_read_urand(syncthing_t)
+
+fs_getattr_xattr_fs(syncthing_t)
+
+auth_use_nsswitch(syncthing_t)
+
+manage_dirs_pattern(syncthing_t, syncthing_config_home_t, syncthing_config_home_t)
+manage_files_pattern(syncthing_t, syncthing_config_home_t, syncthing_config_home_t)
+manage_lnk_files_pattern(syncthing_t, syncthing_config_home_t, syncthing_config_home_t)
+
+miscfiles_read_generic_certs(syncthing_t)
+miscfiles_read_localization(syncthing_t)
+
+userdom_manage_user_home_content_files(syncthing_t)
+userdom_manage_user_home_content_dirs(syncthing_t)
+userdom_manage_user_home_content_symlinks(syncthing_t)
+userdom_user_home_dir_filetrans_user_home_content(syncthing_t, dir)
+
+# newly created files in ~/.config/syncthing/ will transition to syncthing_config_home_t
+userdom_user_home_content_filetrans(syncthing_t, syncthing_config_home_t, dir, "syncthing")
+
+userdom_use_user_terminals(syncthing_t)
+
+optional_policy(`
+    # temporary hack for /run/NetworkManager/resolv.conf until we make this part of sysnet_dns_name_resolve()
+    networkmanager_read_pid_files(syncthing_t)
+')


### PR DESCRIPTION
Policy governing [Syncthing](https://syncthing.org) - a file synchronization utility written in Go.

Dependent upon [TresysTechnology/refpolicy#37](https://github.com/TresysTechnology/refpolicy/pull/37).