### PR TITLE
Fix NetworkManager Read Pid Files Macro

### DIFF
--- a/networkmanager.if
+++ b/networkmanager.if
@@ -247,6 +247,7 @@ interface(`networkmanager_read_pid_files',`
 	')
 
 	files_search_pids($1)
+	allow $1 NetworkManager_var_run_t:dir search_dir_perms;
 	allow $1 NetworkManager_var_run_t:file read_file_perms;
 ')
 


### PR DESCRIPTION
Bug found in pull #26 - permissions aren't granted for searching the `NetworkManager_var_run_t` directory, only to reading its files.

In that PR, granting:

```
networkmanager_read_pid_files(syncthing_t)
```

still results in the following denied:

```
type=AVC msg=audit(1475008204.047:862): avc:  denied  { search } for  pid=8442 comm="syncthing" name="NetworkManager" dev="tmpfs" ino=16551 scontext=system_u:system_r:syncthing_t tcontext=system_u:object_r:NetworkManager_var_run_t tclass=dir permissive=1
```