### PR TITLE
Add file contexts for files in /usr/{lib,sbin}

### DIFF
--- a/cpucontrol.fc
+++ b/cpucontrol.fc
@@ -2,6 +2,8 @@
 
 /sbin/microcode_ctl	--	gen_context(system_u:object_r:cpucontrol_exec_t,s0)
 
+/usr/lib/firmware/microcode.*\.dat -- gen_context(system_u:object_r:cpucontrol_conf_t,s0)
+
 /usr/sbin/cpufreqd	--	gen_context(system_u:object_r:cpuspeed_exec_t,s0)
 /usr/sbin/cpuspeed	--	gen_context(system_u:object_r:cpuspeed_exec_t,s0)
 /usr/sbin/microcode_ctl	--	gen_context(system_u:object_r:cpucontrol_exec_t,s0)

--- a/rpm.fc
+++ b/rpm.fc
@@ -27,6 +27,7 @@
 /usr/sbin/up2date	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/sbin/yum-complete-transaction	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/sbin/system-install-packages	--	gen_context(system_u:object_r:rpm_exec_t,s0)
+/usr/sbin/yast2	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/sbin/yum-updatesd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 /usr/sbin/packagekitd	--	gen_context(system_u:object_r:rpm_exec_t,s0)
 


### PR DESCRIPTION
cpucontrol defines a file context for /lib/firmware/microcode.*\.dat and rpm one for /sbin/yast2. As there are distributions where /bin, /lib and /sbin are symbolic links to /usr/ directories, add the file contexts for the matching /usr files too.