### PR TITLE
corecmd_read_bin_symlinks(): remove deprecated and redundant calls

### DIFF
--- a/dbus.te
+++ b/dbus.te
@@ -195,7 +195,6 @@ kernel_read_system_state(session_bus_type)
 kernel_read_kernel_sysctls(session_bus_type)
 
 corecmd_list_bin(session_bus_type)
-corecmd_read_bin_symlinks(session_bus_type)
 corecmd_read_bin_files(session_bus_type)
 corecmd_read_bin_pipes(session_bus_type)
 corecmd_read_bin_sockets(session_bus_type)

--- a/mailman.te
+++ b/mailman.te
@@ -241,7 +241,6 @@ kernel_read_system_state(mailman_queue_t)
 auth_domtrans_chk_passwd(mailman_queue_t)
 
 corecmd_read_bin_files(mailman_queue_t)
-corecmd_read_bin_symlinks(mailman_queue_t)
 corenet_sendrecv_innd_client_packets(mailman_queue_t)
 corenet_tcp_connect_innd_port(mailman_queue_t)
 corenet_tcp_sendrecv_innd_port(mailman_queue_t)

--- a/nagios.te
+++ b/nagios.te
@@ -297,7 +297,6 @@ optional_policy(`
 #
 
 corecmd_read_bin_files(nagios_admin_plugin_t)
-corecmd_read_bin_symlinks(nagios_admin_plugin_t)
 
 dev_getattr_all_chr_files(nagios_admin_plugin_t)
 dev_getattr_all_blk_files(nagios_admin_plugin_t)
@@ -320,7 +319,6 @@ allow nagios_mail_plugin_t self:tcp_socket { accept listen };
 kernel_read_kernel_sysctls(nagios_mail_plugin_t)
 
 corecmd_read_bin_files(nagios_mail_plugin_t)
-corecmd_read_bin_symlinks(nagios_mail_plugin_t)
 
 files_read_etc_files(nagios_mail_plugin_t)
 

--- a/postfix.te
+++ b/postfix.te
@@ -510,7 +510,6 @@ corenet_tcp_connect_all_ports(postfix_map_t)
 corenet_tcp_sendrecv_all_ports(postfix_map_t)
 
 corecmd_list_bin(postfix_map_t)
-corecmd_read_bin_symlinks(postfix_map_t)
 corecmd_read_bin_files(postfix_map_t)
 corecmd_read_bin_pipes(postfix_map_t)
 corecmd_read_bin_sockets(postfix_map_t)

--- a/ppp.te
+++ b/ppp.te
@@ -257,7 +257,6 @@ kernel_read_system_state(pptp_t)
 kernel_signal(pptp_t)
 
 corecmd_exec_shell(pptp_t)
-corecmd_read_bin_symlinks(pptp_t)
 
 corenet_all_recvfrom_unlabeled(pptp_t)
 corenet_all_recvfrom_netlabel(pptp_t)

--- a/prelink.te
+++ b/prelink.te
@@ -72,7 +72,6 @@ kernel_read_kernel_sysctls(prelink_t)
 corecmd_manage_all_executables(prelink_t)
 corecmd_relabel_all_executables(prelink_t)
 corecmd_mmap_all_executables(prelink_t)
-corecmd_read_bin_symlinks(prelink_t)
 
 dev_read_urand(prelink_t)
 

--- a/remotelogin.te
+++ b/remotelogin.te
@@ -48,7 +48,6 @@ auth_rw_login_records(remote_login_t)
 auth_rw_faillog(remote_login_t)
 
 corecmd_list_bin(remote_login_t)
-corecmd_read_bin_symlinks(remote_login_t)
 
 domain_read_all_entry_files(remote_login_t)
 

--- a/rshd.te
+++ b/rshd.te
@@ -27,6 +27,8 @@ allow rshd_t rshd_keytab_t:file read_file_perms;
 
 kernel_read_kernel_sysctls(rshd_t)
 
+corecmd_search_bin(rshd_t)
+
 corenet_all_recvfrom_unlabeled(rshd_t)
 corenet_all_recvfrom_netlabel(rshd_t)
 corenet_tcp_sendrecv_generic_if(rshd_t)
@@ -39,8 +41,6 @@ corenet_tcp_bind_rsh_port(rshd_t)
 corenet_tcp_bind_all_rpc_ports(rshd_t)
 corenet_tcp_connect_all_ports(rshd_t)
 corenet_tcp_connect_all_rpc_ports(rshd_t)
-
-corecmd_read_bin_symlinks(rshd_t)
 
 files_list_home(rshd_t)
 

--- a/samhain.te
+++ b/samhain.te
@@ -65,7 +65,6 @@ files_pid_filetrans(samhain_domain, samhain_var_run_t, file)
 kernel_getattr_core_if(samhain_domain)
 
 corecmd_list_bin(samhain_domain)
-corecmd_read_bin_symlinks(samhain_domain)
 
 dev_read_urand(samhain_domain)
 dev_dontaudit_read_rand(samhain_domain)

--- a/screen.te
+++ b/screen.te
@@ -58,7 +58,6 @@ kernel_read_kernel_sysctls(screen_domain)
 
 corecmd_list_bin(screen_domain)
 corecmd_read_bin_files(screen_domain)
-corecmd_read_bin_symlinks(screen_domain)
 corecmd_read_bin_pipes(screen_domain)
 corecmd_read_bin_sockets(screen_domain)
 

--- a/vlock.te
+++ b/vlock.te
@@ -24,7 +24,6 @@ allow vlock_t self:fifo_file rw_fifo_file_perms;
 kernel_read_system_state(vlock_t)
 
 corecmd_list_bin(vlock_t)
-corecmd_read_bin_symlinks(vlock_t)
 
 domain_use_interactive_fds(vlock_t)
 


### PR DESCRIPTION
after the changes to corecmd_search_bin() corecmd_read_bin_symlinks() is deprecated