### PR TITLE
Add a policy for ejabberd.

### DIFF
--- a/ejabberd.fc
+++ b/ejabberd.fc
@@ -1,0 +1,7 @@
+/usr/bin/ejabberdctl    --  gen_context(system_u:object_r:ejabberd_exec_t,s0)
+
+/usr/lib/systemd/system/ejabberd.* -- gen_context(system_u:object_r:ejabberd_unit_t,s0)
+
+/var/lib/ejabberd(/.*)? gen_context(system_u:object_r:ejabberd_var_lib_t,s0)
+
+/var/log/ejabberd(/.*)? gen_context(system_u:object_r:ejabberd_var_log_t,s0)

--- a/ejabberd.if
+++ b/ejabberd.if
@@ -1,0 +1,33 @@
+########################################
+## <summary>
+##	All of the rules required to
+##	administrate an ejabberd environment.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`ejabberd_admin',`
+	gen_require(`
+		type ejabberd_t, ejabberd_exec_t;
+		type ejabberd_var_lib_t, ejabberd_var_log_t;
+	')
+
+    admin_process_pattern($1, ejabberd_t)
+
+    init_startstop_service($1, $2, ejabberd_t, ejabberd_initrc_exec_t, ejabberd_unit_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, ejabberd_var_lib_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, ejabberd_var_log_t)
+')

--- a/ejabberd.te
+++ b/ejabberd.te
@@ -1,0 +1,57 @@
+policy_module(ejabberd,0.0)
+
+
+# Private type declarations
+type ejabberd_t;
+type ejabberd_exec_t;
+type ejabberd_unit_t;
+systemd_unit_file(ejabberd_unit_t)
+type ejabberd_var_lib_t;
+files_type(ejabberd_var_lib_t)
+type ejabberd_var_log_t;
+
+
+init_daemon_domain(ejabberd_t, ejabberd_exec_t)
+
+logging_log_file(ejabberd_var_log_t)
+
+
+# What will we allow
+allow ejabberd_t self:tcp_socket { accept bind connect create getattr getopt listen read setopt write };
+allow ejabberd_t self:udp_socket { bind connect create getattr getopt read setopt write };
+allow ejabberd_t self:unix_dgram_socket { connect create getopt setopt write };
+
+auth_use_nsswitch(ejabberd_t)
+
+corecmd_exec_bin(ejabberd_t)
+corecmd_exec_shell(ejabberd_t)
+
+corenet_tcp_bind_epmd_port(ejabberd_t)
+corenet_tcp_bind_generic_node(ejabberd_t)
+corenet_tcp_bind_generic_port(ejabberd_t)
+corenet_tcp_bind_jabber_client_port(ejabberd_t)
+corenet_tcp_bind_jabber_interserver_port(ejabberd_t)
+corenet_tcp_connect_epmd_port(ejabberd_t)
+corenet_tcp_connect_generic_port(ejabberd_t)
+corenet_tcp_connect_jabber_interserver_port(ejabberd_t)
+
+corenet_udp_bind_generic_node(ejabberd_t)
+
+dev_read_rand(ejabberd_t)
+dev_read_sysfs(ejabberd_t)
+
+files_search_var_lib(ejabberd_t, ejabberd_var_lib_t, dir)
+
+kernel_dgram_send(ejabberd_t)
+
+logging_send_syslog_msg(ejabberd_t)
+logging_log_filetrans(ejabberd_t, ejabberd_var_log_t, { dir file })
+
+manage_dirs_pattern(ejabberd_t, ejabberd_var_lib_t, ejabberd_var_lib_t)
+manage_dirs_pattern(ejabberd_t, ejabberd_var_log_t, ejabberd_var_log_t)
+manage_files_pattern(ejabberd_t, ejabberd_var_lib_t, ejabberd_var_lib_t)
+manage_files_pattern(ejabberd_t, ejabberd_var_log_t, ejabberd_var_log_t)
+
+miscfiles_read_generic_certs(ejabberd_t)
+
+sysnet_read_config(ejabberd_t)


### PR DESCRIPTION
This pull request may depend on https://github.com/TresysTechnology/refpolicy/issues/114 being fixed to work effectively, but I wanted to go ahead and get the code upstream. I've also send a PR with this code to Fedora's contrib policy:

https://github.com/fedora-selinux/selinux-policy-contrib/pull/8

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>