### PR TITLE
mysql update

### DIFF
--- a/mysql.fc
+++ b/mysql.fc
@@ -1,27 +1,27 @@
-HOME_DIR/\.my\.cnf	--	gen_context(system_u:object_r:mysqld_home_t,s0)
+HOME_DIR/\.my\.cnf			--	gen_context(system_u:object_r:mysqld_home_t,s0)
 
-/etc/my\.cnf	--	gen_context(system_u:object_r:mysqld_etc_t,s0)
-/etc/my\.cnf\.d(/.*)?	gen_context(system_u:object_r:mysqld_etc_t,s0)
-/etc/mysql(/.*)?	gen_context(system_u:object_r:mysqld_etc_t,s0)
+/etc/my\.cnf				--	gen_context(system_u:object_r:mysqld_etc_t,s0)
+/etc/my\.cnf\.d(/.*)?				gen_context(system_u:object_r:mysqld_etc_t,s0)
+/etc/mysql(/.*)?				gen_context(system_u:object_r:mysqld_etc_t,s0)
 
-/etc/rc\.d/init\.d/mysqld?	--	gen_context(system_u:object_r:mysqld_initrc_exec_t,s0)
+/etc/rc\.d/init\.d/mysqld?		--	gen_context(system_u:object_r:mysqld_initrc_exec_t,s0)
 
-/usr/bin/mysqld(-max)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/mysqld_safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
-/usr/bin/mysql_upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/mysqld(-max)?			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/mysqld_safe			--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
+/usr/bin/mysql_upgrade			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/ndbd				--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/lib/systemd/system/mysqld.*\.service -- gen_context(system_u:object_r:mysqld_unit_t,s0)
+/usr/lib/systemd/system/mysqld.*\.service --	gen_context(system_u:object_r:mysqld_unit_t,s0)
 
-/usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/libexec/mysqld			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/sbin/mysqld(-max)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/sbin/ndbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/sbin/mysqld(-max)?			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/sbin/ndbd				--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/var/lib/mysql(/.*)?	gen_context(system_u:object_r:mysqld_db_t,s0)
-/var/lib/mysql/mysql.*	-s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
+/var/lib/mysql(/.*)?				gen_context(system_u:object_r:mysqld_db_t,s0)
+/var/lib/mysql/mysql.*			-s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
 
-/var/log/mariadb(/.*)?	gen_context(system_u:object_r:mysqld_log_t,s0)
-/var/log/mysql.*	--	gen_context(system_u:object_r:mysqld_log_t,s0)
+/var/log/mariadb(/.*)?				gen_context(system_u:object_r:mysqld_log_t,s0)
+/var/log/mysql.*			--	gen_context(system_u:object_r:mysqld_log_t,s0)
 
-/run/mysqld.*	gen_context(system_u:object_r:mysqld_var_run_t,s0)
+/run/mysqld.*					gen_context(system_u:object_r:mysqld_var_run_t,s0)

--- a/mysql.fc
+++ b/mysql.fc
@@ -1,27 +1,24 @@
 HOME_DIR/\.my\.cnf			--	gen_context(system_u:object_r:mysqld_home_t,s0)
 
-/etc/my\.cnf				--	gen_context(system_u:object_r:mysqld_etc_t,s0)
-/etc/my\.cnf\.d(/.*)?				gen_context(system_u:object_r:mysqld_etc_t,s0)
-/etc/mysql(/.*)?				gen_context(system_u:object_r:mysqld_etc_t,s0)
+/etc/my\.cnf				--	gen_context(system_u:object_r:mysqld_conf_t,s0)
+/etc/my\.cnf\.d(/.*)?				gen_context(system_u:object_r:mysqld_conf_t,s0)
+/etc/mysql(/.*)?				gen_context(system_u:object_r:mysqld_conf_t,s0)
 
 /etc/rc\.d/init\.d/mysqld?		--	gen_context(system_u:object_r:mysqld_initrc_exec_t,s0)
 
+/run/mysqld.*					gen_context(system_u:object_r:mysqld_runtime_t,s0)
+
 /usr/bin/mysqld(-max)?			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mysqld_safe			--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
-/usr/bin/mysql_upgrade			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/ndbd				--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
-/usr/lib/systemd/system/mysqld.*\.service --	gen_context(system_u:object_r:mysqld_unit_t,s0)
-
-/usr/libexec/mysqld			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/lib/systemd/system/mysqld[^/]*\.service --	gen_context(system_u:object_r:mysqld_unit_t,s0)
+/usr/lib/systemd/system/mariadb[^/]*\.service -- gen_context(system_u:object_r:mysqld_unit_t,s0)
 
 /usr/sbin/mysqld(-max)?			--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/sbin/ndbd				--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /var/lib/mysql(/.*)?				gen_context(system_u:object_r:mysqld_db_t,s0)
-/var/lib/mysql/mysql.*			-s	gen_context(system_u:object_r:mysqld_var_run_t,s0)
+/var/lib/mysql/mysql.*			-s	gen_context(system_u:object_r:mysqld_runtime_t,s0)
 
 /var/log/mariadb(/.*)?				gen_context(system_u:object_r:mysqld_log_t,s0)
-/var/log/mysql.*			--	gen_context(system_u:object_r:mysqld_log_t,s0)
-
-/run/mysqld.*					gen_context(system_u:object_r:mysqld_var_run_t,s0)
+/var/log/mysql(/.*)?				gen_context(system_u:object_r:mysqld_log_t,s0)

--- a/mysql.fc
+++ b/mysql.fc
@@ -5,12 +5,10 @@ HOME_DIR/\.my\.cnf	--	gen_context(system_u:object_r:mysqld_home_t,s0)
 /etc/mysql(/.*)?	gen_context(system_u:object_r:mysqld_etc_t,s0)
 
 /etc/rc\.d/init\.d/mysqld?	--	gen_context(system_u:object_r:mysqld_initrc_exec_t,s0)
-/etc/rc\.d/init\.d/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_initrc_exec_t,s0)
 
 /usr/bin/mysqld(-max)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/mysqld_safe	--	gen_context(system_u:object_r:mysqld_safe_exec_t,s0)
 /usr/bin/mysql_upgrade	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/bin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/bin/ndbd		--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/lib/systemd/system/mysqld.*\.service -- gen_context(system_u:object_r:mysqld_unit_t,s0)
@@ -18,7 +16,6 @@ HOME_DIR/\.my\.cnf	--	gen_context(system_u:object_r:mysqld_home_t,s0)
 /usr/libexec/mysqld	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /usr/sbin/mysqld(-max)?	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
-/usr/sbin/mysqlmanager	--	gen_context(system_u:object_r:mysqlmanagerd_exec_t,s0)
 /usr/sbin/ndbd	--	gen_context(system_u:object_r:mysqld_exec_t,s0)
 
 /var/lib/mysql(/.*)?	gen_context(system_u:object_r:mysqld_db_t,s0)
@@ -28,5 +25,3 @@ HOME_DIR/\.my\.cnf	--	gen_context(system_u:object_r:mysqld_home_t,s0)
 /var/log/mysql.*	--	gen_context(system_u:object_r:mysqld_log_t,s0)
 
 /run/mysqld.*	gen_context(system_u:object_r:mysqld_var_run_t,s0)
-/run/mysqlmanager.*	--	gen_context(system_u:object_r:mysqlmanagerd_var_run_t,s0)
-/run/mysqld/mysqlmanager.*	--	gen_context(system_u:object_r:mysqlmanagerd_var_run_t,s0)

--- a/mysql.if
+++ b/mysql.if
@@ -30,6 +30,7 @@ interface(`mysql_role',`
 ## </param>
 #
 interface(`mysql_domtrans',`
+	refpolicywarn(`$0($*) has been deprecated')
 	gen_require(`
 		type mysqld_t, mysqld_exec_t;
 	')
@@ -55,6 +56,7 @@ interface(`mysql_domtrans',`
 ## </param>
 #
 interface(`mysql_run_mysqld',`
+	refpolicywarn(`$0($*) has been deprecated')
 	gen_require(`
 		attribute_role mysqld_roles;
 	')
@@ -116,11 +118,11 @@ interface(`mysql_tcp_connect',`
 #
 interface(`mysql_stream_connect',`
 	gen_require(`
-		type mysqld_t, mysqld_var_run_t, mysqld_db_t;
+		type mysqld_t, mysqld_runtime_t, mysqld_db_t;
 	')
 
 	files_search_pids($1)
-	stream_connect_pattern($1, { mysqld_db_t mysqld_var_run_t }, mysqld_var_run_t, mysqld_t)
+	stream_connect_pattern($1, { mysqld_db_t mysqld_runtime_t }, mysqld_runtime_t, mysqld_t)
 ')
 
 ########################################
@@ -136,13 +138,13 @@ interface(`mysql_stream_connect',`
 #
 interface(`mysql_read_config',`
 	gen_require(`
-		type mysqld_etc_t;
+		type mysqld_conf_t;
 	')
 
 	files_search_etc($1)
-	allow $1 mysqld_etc_t:dir list_dir_perms;
-	allow $1 mysqld_etc_t:file read_file_perms;
-	allow $1 mysqld_etc_t:lnk_file read_lnk_file_perms;
+	allow $1 mysqld_conf_t:dir list_dir_perms;
+	allow $1 mysqld_conf_t:file read_file_perms;
+	allow $1 mysqld_conf_t:lnk_file read_lnk_file_perms;
 ')
 
 ########################################
@@ -355,6 +357,8 @@ interface(`mysql_home_filetrans_mysqld_home',`
 ## </param>
 #
 interface(`mysql_write_log',`
+	refpolicywarn(`$0($*) has been deprecated.')
+
 	gen_require(`
 		type mysqld_log_t;
 	')
@@ -395,11 +399,11 @@ interface(`mysql_domtrans_mysql_safe',`
 #
 interface(`mysql_read_pid_files',`
 	gen_require(`
-		type mysqld_var_run_t;
+		type mysqld_runtime_t;
 	')
 
 	files_search_pids($1)
-	read_files_pattern($1, mysqld_var_run_t, mysqld_var_run_t)
+	read_files_pattern($1, mysqld_runtime_t, mysqld_runtime_t)
 ')
 
 #####################################
@@ -415,11 +419,11 @@ interface(`mysql_read_pid_files',`
 #
 interface(`mysql_search_pid_files',`
 	gen_require(`
-		type mysqld_var_run_t;
+		type mysqld_runtime_t;
 	')
 
 	files_search_pids($1)
-	search_dirs_pattern($1, mysqld_var_run_t, mysqld_var_run_t)
+	search_dirs_pattern($1, mysqld_runtime_t, mysqld_runtime_t)
 ')
 
 ########################################
@@ -441,30 +445,29 @@ interface(`mysql_search_pid_files',`
 #
 interface(`mysql_admin',`
 	gen_require(`
-		type mysqld_t, mysqld_var_run_t, mysqld_etc_t;
+		type mysqld_t, mysqld_runtime_t, mysqld_conf_t;
 		type mysqld_tmp_t, mysqld_db_t, mysqld_log_t;
 		type mysqld_safe_t, mysqld_initrc_exec_t, mysqld_home_t;
+		type mysqld_unit_t;
 	')
 
-	allow $1 { mysqld_safe_t mysqld_t }:process { ptrace signal_perms };
-	ps_process_pattern($1, { mysqld_safe_t mysqld_t })
+	admin_process_pattern($1, { mysqld_safe_t mysqld_t })
+	allow $1 mysqld_t:unix_stream_socket connectto;
 
-	init_startstop_service($1, $2, mysqld_t, mysqld_initrc_exec_t)
+	init_startstop_service($1, $2, mysqld_t, mysqld_initrc_exec_t, mysqld_unit_t)
 
 	files_search_pids($1)
-	admin_pattern($1, mysqld_var_run_t)
+	admin_pattern($1, mysqld_runtime_t)
 
 	files_search_var_lib($1)
 	admin_pattern($1, mysqld_db_t)
 
 	files_search_etc($1)
-	admin_pattern($1, { mysqld_etc_t mysqld_home_t })
+	admin_pattern($1, { mysqld_conf_t mysqld_home_t })
 
 	logging_search_logs($1)
 	admin_pattern($1, mysqld_log_t)
 
 	files_search_tmp($1)
 	admin_pattern($1, mysqld_tmp_t)
-
-	mysql_run_mysqld($1, $2)
 ')

--- a/mysql.if
+++ b/mysql.if
@@ -443,18 +443,16 @@ interface(`mysql_admin',`
 	gen_require(`
 		type mysqld_t, mysqld_var_run_t, mysqld_etc_t;
 		type mysqld_tmp_t, mysqld_db_t, mysqld_log_t;
-		type mysqld_safe_t, mysqlmanagerd_t, mysqlmanagerd_var_run_t;
-		type mysqld_initrc_exec_t, mysqlmanagerd_initrc_exec_t, mysqld_home_t;
+		type mysqld_safe_t, mysqld_initrc_exec_t, mysqld_home_t;
 	')
 
-	allow $1 { mysqld_safe_t mysqld_t mysqlmanagerd_t }:process { ptrace signal_perms };
-	ps_process_pattern($1, { mysqld_safe_t mysqld_t mysqlmanagerd_t })
+	allow $1 { mysqld_safe_t mysqld_t }:process { ptrace signal_perms };
+	ps_process_pattern($1, { mysqld_safe_t mysqld_t })
 
 	init_startstop_service($1, $2, mysqld_t, mysqld_initrc_exec_t)
-	init_startstop_service($1, $2, mysqlmanagerd_t, mysqlmanagerd_initrc_exec_t)
 
 	files_search_pids($1)
-	admin_pattern($1, { mysqlmanagerd_var_run_t mysqld_var_run_t })
+	admin_pattern($1, mysqld_var_run_t)
 
 	files_search_var_lib($1)
 	admin_pattern($1, mysqld_db_t)

--- a/mysql.te
+++ b/mysql.te
@@ -18,22 +18,20 @@ attribute_role mysqld_roles;
 type mysqld_t;
 type mysqld_exec_t;
 init_daemon_domain(mysqld_t, mysqld_exec_t)
-application_domain(mysqld_t, mysqld_exec_t)
 role mysqld_roles types mysqld_t;
 
 type mysqld_safe_t;
 type mysqld_safe_exec_t;
 init_daemon_domain(mysqld_safe_t, mysqld_safe_exec_t)
 
-type mysqld_var_run_t;
-files_pid_file(mysqld_var_run_t)
-init_daemon_pid_file(mysqld_var_run_t, dir, "mysqld")
+type mysqld_runtime_t alias mysqld_var_run_t;
+init_daemon_pid_file(mysqld_runtime_t, dir, "mysqld")
 
 type mysqld_db_t;
 files_type(mysqld_db_t)
 
-type mysqld_etc_t alias etc_mysqld_t;
-files_config_file(mysqld_etc_t)
+type mysqld_conf_t alias mysqld_etc_t;
+files_config_file(mysqld_conf_t)
 
 type mysqld_home_t;
 userdom_user_home_content(mysqld_home_t)
@@ -66,27 +64,25 @@ allow mysqld_t self:tcp_socket { accept listen };
 manage_dirs_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
 manage_lnk_files_pattern(mysqld_t, mysqld_db_t, mysqld_db_t)
-files_var_lib_filetrans(mysqld_t, mysqld_db_t, { dir file lnk_file })
 
-filetrans_pattern(mysqld_t, mysqld_db_t, mysqld_var_run_t, sock_file)
+filetrans_pattern(mysqld_t, mysqld_db_t, mysqld_runtime_t, sock_file)
 
-allow mysqld_t mysqld_etc_t:dir list_dir_perms;
-allow mysqld_t { mysqld_etc_t mysqld_home_t }:file read_file_perms;
-allow mysqld_t mysqld_etc_t:lnk_file read_lnk_file_perms;
+allow mysqld_t mysqld_conf_t:dir list_dir_perms;
+allow mysqld_t { mysqld_conf_t mysqld_home_t }:file read_file_perms;
+allow mysqld_t mysqld_conf_t:lnk_file read_lnk_file_perms;
 
-manage_dirs_pattern(mysqld_t, mysqld_log_t, mysqld_log_t)
-manage_files_pattern(mysqld_t, mysqld_log_t, mysqld_log_t)
-manage_lnk_files_pattern(mysqld_t, mysqld_log_t, mysqld_log_t)
+allow mysqld_t mysqld_log_t:dir { add_entry_dir_perms create };
+allow mysqld_t mysqld_log_t:file { append_file_perms create };
 logging_log_filetrans(mysqld_t, mysqld_log_t, { dir file })
 
 manage_dirs_pattern(mysqld_t, mysqld_tmp_t, mysqld_tmp_t)
 manage_files_pattern(mysqld_t, mysqld_tmp_t, mysqld_tmp_t)
 files_tmp_filetrans(mysqld_t, mysqld_tmp_t, { file dir })
 
-manage_dirs_pattern(mysqld_t, mysqld_var_run_t, mysqld_var_run_t)
-manage_files_pattern(mysqld_t, mysqld_var_run_t, mysqld_var_run_t)
-manage_sock_files_pattern(mysqld_t, mysqld_var_run_t, mysqld_var_run_t)
-files_pid_filetrans(mysqld_t, mysqld_var_run_t, { dir file sock_file })
+manage_dirs_pattern(mysqld_t, mysqld_runtime_t, mysqld_runtime_t)
+manage_files_pattern(mysqld_t, mysqld_runtime_t, mysqld_runtime_t)
+manage_sock_files_pattern(mysqld_t, mysqld_runtime_t, mysqld_runtime_t)
+files_pid_filetrans(mysqld_t, mysqld_runtime_t, { dir file sock_file })
 
 kernel_read_kernel_sysctls(mysqld_t)
 kernel_read_network_state(mysqld_t)
@@ -119,6 +115,7 @@ fs_rw_hugetlbfs_files(mysqld_t)
 
 files_read_etc_runtime_files(mysqld_t)
 files_read_usr_files(mysqld_t)
+files_search_var_lib(mysqld_t)
 
 auth_use_nsswitch(mysqld_t)
 
@@ -161,17 +158,17 @@ allow mysqld_safe_t mysqld_t:process { signull sigkill };
 read_lnk_files_pattern(mysqld_safe_t, mysqld_db_t, mysqld_db_t)
 manage_files_pattern(mysqld_safe_t, mysqld_db_t, mysqld_db_t)
 
-allow mysqld_safe_t mysqld_etc_t:dir list_dir_perms;
-allow mysqld_safe_t { mysqld_etc_t mysqld_home_t }:file read_file_perms;
-allow mysqld_safe_t mysqld_etc_t:lnk_file read_lnk_file_perms;
+allow mysqld_safe_t mysqld_conf_t:dir list_dir_perms;
+allow mysqld_safe_t { mysqld_conf_t mysqld_home_t }:file read_file_perms;
+allow mysqld_safe_t mysqld_conf_t:lnk_file read_lnk_file_perms;
 
 list_dirs_pattern(mysqld_safe_t, mysqld_log_t, mysqld_log_t)
 manage_files_pattern(mysqld_safe_t, mysqld_log_t, mysqld_log_t)
 manage_lnk_files_pattern(mysqld_safe_t, mysqld_log_t, mysqld_log_t)
 logging_log_filetrans(mysqld_safe_t, mysqld_log_t, file)
 
-manage_files_pattern(mysqld_safe_t, mysqld_var_run_t, mysqld_var_run_t)
-delete_sock_files_pattern(mysqld_safe_t, { mysqld_db_t mysqld_var_run_t }, mysqld_var_run_t)
+manage_files_pattern(mysqld_safe_t, mysqld_runtime_t, mysqld_runtime_t)
+delete_sock_files_pattern(mysqld_safe_t, { mysqld_db_t mysqld_runtime_t }, mysqld_runtime_t)
 
 domtrans_pattern(mysqld_safe_t, mysqld_exec_t, mysqld_t)
 

--- a/mysql.te
+++ b/mysql.te
@@ -50,16 +50,6 @@ files_tmp_file(mysqld_tmp_t)
 type mysqld_unit_t;
 init_unit_file(mysqld_unit_t)
 
-type mysqlmanagerd_t;
-type mysqlmanagerd_exec_t;
-init_daemon_domain(mysqlmanagerd_t, mysqlmanagerd_exec_t)
-
-type mysqlmanagerd_initrc_exec_t;
-init_script_file(mysqlmanagerd_initrc_exec_t)
-
-type mysqlmanagerd_var_run_t;
-files_pid_file(mysqlmanagerd_var_run_t)
-
 ########################################
 #
 # Local policy
@@ -210,55 +200,3 @@ userdom_search_user_home_dirs(mysqld_safe_t)
 optional_policy(`
 	hostname_exec(mysqld_safe_t)
 ')
-
-########################################
-#
-# Manager local policy
-#
-
-allow mysqlmanagerd_t self:capability { dac_override kill };
-allow mysqlmanagerd_t self:process signal;
-allow mysqlmanagerd_t self:fifo_file rw_fifo_file_perms;
-allow mysqlmanagerd_t self:tcp_socket create_stream_socket_perms;
-allow mysqlmanagerd_t self:unix_stream_socket create_stream_socket_perms;
-
-allow mysqlmanagerd_t mysqld_t:process signal;
-
-allow mysqlmanagerd_t mysqld_etc_t:dir list_dir_perms;
-allow mysqlmanagerd_t { mysqld_etc_t mysqld_home_t }:file read_file_perms;
-allow mysqlmanagerd_t mysqld_etc_t:lnk_file read_lnk_file_perms;
-
-domtrans_pattern(mysqlmanagerd_t, mysqld_exec_t, mysqld_t)
-
-manage_files_pattern(mysqlmanagerd_t, mysqld_var_run_t, mysqlmanagerd_var_run_t)
-manage_sock_files_pattern(mysqlmanagerd_t, mysqld_var_run_t, mysqlmanagerd_var_run_t)
-filetrans_pattern(mysqlmanagerd_t, mysqld_var_run_t, mysqlmanagerd_var_run_t, { file sock_file })
-
-stream_connect_pattern(mysqlmanagerd_t, { mysqld_db_t mysqld_var_run_t }, mysqld_var_run_t, mysqld_t)
-
-kernel_read_system_state(mysqlmanagerd_t)
-
-corecmd_exec_shell(mysqlmanagerd_t)
-
-corenet_all_recvfrom_unlabeled(mysqlmanagerd_t)
-corenet_all_recvfrom_netlabel(mysqlmanagerd_t)
-corenet_tcp_sendrecv_generic_if(mysqlmanagerd_t)
-corenet_tcp_sendrecv_generic_node(mysqlmanagerd_t)
-corenet_tcp_bind_generic_node(mysqlmanagerd_t)
-
-corenet_sendrecv_mysqlmanagerd_server_packets(mysqlmanagerd_t)
-corenet_tcp_bind_mysqlmanagerd_port(mysqlmanagerd_t)
-corenet_sendrecv_mysqlmanagerd_client_packets(mysqlmanagerd_t)
-corenet_tcp_connect_mysqlmanagerd_port(mysqlmanagerd_t)
-corenet_tcp_sendrecv_mysqlmanagerd_port(mysqlmanagerd_t)
-
-dev_read_urand(mysqlmanagerd_t)
-
-files_read_etc_files(mysqlmanagerd_t)
-files_read_usr_files(mysqlmanagerd_t)
-files_search_pids(mysqlmanagerd_t)
-files_search_var_lib(mysqlmanagerd_t)
-
-miscfiles_read_localization(mysqlmanagerd_t)
-
-userdom_search_user_home_dirs(mysqlmanagerd_t)


### PR DESCRIPTION
* remove policy for `mysqlmanager`, removed in mysql 5.5
* rename `mysqld_etc_t` to `mysqld_conf_t` and `mysqld_var_run_t` to `mysqld_runtime_t`
* tweak admin interface
* stricter access to log files