### PR TITLE
dbus-broker: add policy module

### DIFF
--- a/dbus.fc
+++ b/dbus.fc
@@ -8,6 +8,8 @@ HOME_DIR/\.dbus(/.*)?				gen_context(system_u:object_r:session_dbusd_home_t,s0)
 /run/user/%{USERID}/dbus-1(/.*)?		gen_context(system_u:object_r:session_dbusd_runtime_t,s0)
 
 /usr/bin/dbus-daemon(-1)?		--	gen_context(system_u:object_r:dbusd_exec_t,s0)
+/usr/bin/dbus-broker-launch		--	gen_context(system_u:object_r:dbusd_exec_t,s0) # needed by dbus-broker
+/usr/bin/dbus-broker			--	gen_context(system_u:object_r:dbusd_exec_t,s0) # needed by dbus-broker
 
 /usr/lib/dbus-.*/dbus-daemon-launch-helper	--	gen_context(system_u:object_r:dbusd_exec_t,s0)
 

--- a/dbus.te
+++ b/dbus.te
@@ -133,6 +133,7 @@ auth_read_pam_console_data(system_dbusd_t)
 init_use_fds(system_dbusd_t)
 init_use_script_ptys(system_dbusd_t)
 init_all_labeled_script_domtrans(system_dbusd_t)
+init_start_system(system_dbusd_t) # needed by dbus-broker
 
 logging_send_audit_msgs(system_dbusd_t)
 logging_send_syslog_msg(system_dbusd_t)


### PR DESCRIPTION
dbus-broker is a drop in replacement for dbus-daemon. It can therefore
mostly simply rely on the dbus policy module. However, it also needs to
have its binaries labeled correctly, and it needs permission to perform
the D-Bus method call StartTransientUnit on PID1, which dbus-daemon did
not.

For details see <https://github.com/bus1/dbus-broker/wiki>.