### PR TITLE
Allow NetworkManager to write to audit

### DIFF
--- a/networkmanager.te
+++ b/networkmanager.te
@@ -155,6 +155,7 @@ init_domtrans_script(NetworkManager_t)
 
 auth_use_nsswitch(NetworkManager_t)
 
+logging_send_audit_msgs(NetworkManager_t)
 logging_send_syslog_msg(NetworkManager_t)
 
 miscfiles_read_generic_certs(NetworkManager_t)


### PR DESCRIPTION
Since version 1.2, NetworkManager can log events to audit