### PR TITLE
Update pkcs policy to include pkccsslotd.service

### DIFF
--- a/pkcs.fc
+++ b/pkcs.fc
@@ -2,6 +2,8 @@
 
 /usr/bin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)
 
+/usr/lib/systemd/system/pkcsslotd.service  gen_context(system_u:object_r:pkcs_slotd_unit_file_t,s0)
+
 /usr/sbin/pkcsslotd	--	gen_context(system_u:object_r:pkcs_slotd_exec_t,s0)
 
 /var/lib/opencryptoki(/.*)?	gen_context(system_u:object_r:pkcs_slotd_var_lib_t,s0)

--- a/pkcs.te
+++ b/pkcs.te
@@ -24,6 +24,9 @@ files_tmp_file(pkcs_slotd_tmp_t)
 type pkcs_slotd_tmpfs_t;
 files_tmpfs_file(pkcs_slotd_tmpfs_t)
 
+type pkcs_slotd_unit_file_t;
+init_unit_file(pkcs_slotd_unit_file_t)
+
 ########################################
 #
 # Local policy

--- a/pkcs.te
+++ b/pkcs.te
@@ -54,9 +54,11 @@ files_tmp_filetrans(pkcs_slotd_t, pkcs_slotd_tmp_t, dir)
 
 manage_dirs_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
 manage_files_pattern(pkcs_slotd_t, pkcs_slotd_tmpfs_t, pkcs_slotd_tmpfs_t)
-fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, dir)
+fs_tmpfs_filetrans(pkcs_slotd_t, pkcs_slotd_tmpfs_t, { dir file })
 
 files_read_etc_files(pkcs_slotd_t)
+
+auth_use_nsswitch(pkcs_slotd_t)
 
 logging_send_syslog_msg(pkcs_slotd_t)
 


### PR DESCRIPTION
pkcsslotd.service was not receiving a proper label. Fixed it by creating the pkcs_slotd_unit_file_t type and updating the file context.
Also updated some missing permissions, like access to tmpfs files and /etc/group file.